### PR TITLE
Add event handling to fix rendering issues on Windows

### DIFF
--- a/mpe2/_mpe_utils/simple_env.py
+++ b/mpe2/_mpe_utils/simple_env.py
@@ -284,6 +284,15 @@ class SimpleEnv(AECEnv):
             return
 
         self.enable_render(self.render_mode)
+        # Add event handling to fix rendering issues on Windows
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                return
+            if event.type == pygame.WINDOWCLOSE:
+                pygame.quit()
+                return
+        pygame.event.pump()  # 确保事件系统正常运行
 
         self.draw()
         if self.render_mode == "rgb_array":


### PR DESCRIPTION
On macOS, special event handling is not required because the window management system and event handling mechanism 
        differ from Windows. macOS has a better window management system that doesn't cause the program to become unresponsive 
        even without processing the event queue.
        This design can:
                1. Prevent unresponsiveness on Windows
                2. Work properly on Mac as well
                3. Provide better user experience (e.g., correctly responding to window close button)
                Therefore, it's recommended to keep this event handling code so your program works properly on any platform.

