### PR TITLE
Fix benchmark infos for simple_spread

### DIFF
--- a/mpe2/simple_spread/simple_spread.py
+++ b/mpe2/simple_spread/simple_spread.py
@@ -157,7 +157,7 @@ class Scenario(BaseScenario):
                 occupied_landmarks += 1
         if agent.collide:
             for a in world.agents:
-                if self.is_collision(a, agent):
+                if self.is_collision(a, agent) and a != agent:
                     rew -= 1
                     collisions += 1
         return (rew, collisions, min_dists, occupied_landmarks)


### PR DESCRIPTION
# Fixed
- simple_spread no longer reports collisions with itself for infos/benchmarking.

This is likely the intended behaviour given the reward function as:

`rew -= 1.0 * (self.is_collision(a, agent) and a != agent)`