### PR TITLE
Remove Python 3.9 support

### DIFF
--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -27,7 +27,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+                python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -31,7 +31,7 @@ jobs:
             matrix:
                 # macos-13: Intel (x86_64), macos-latest: Apple Silicon (arm64)
                 os: [macos-latest]
-                python-version: ['3.9', '3.14']
+                python-version: ['3.10', '3.14']
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 name = "mpe2"
 description = "Multi Particle Environments Version 2"
 readme = "README.md"
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 authors = [{ name = "Farama Foundation", email = "contact@farama.org" }]
 license = { text = "MIT License" }
 keywords = ["Reinforcement Learning", "game", "RL", "AI", "gymnasium"]
@@ -16,7 +16,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
# Description

Fixes #55.

Python 3.9 is end-of-life and has been deprecated for some time, so this drops it and bumps the minimum supported version to 3.10:

- **`pyproject.toml`** — `requires-python = ">= 3.10"` and remove the `Programming Language :: Python :: 3.9` classifier.
- **`.github/workflows/linux-test.yml`** — remove `3.9` from the test matrix (now `3.10`–`3.14`).
- **`.github/workflows/macos-test.yml`** — bump the matrix's lower bound from `3.9` to `3.10` (keeps the min/max `['3.10', '3.14']` pattern).

No source changes were needed — there are no `3.9`-specific code paths or version conditionals in the package (grep for `3.9` / `version_info` is clean after this change).

## Type of change

- Maintenance (drop end-of-life Python version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
