### PR TITLE
Fix collect treasure event rewards

### DIFF
--- a/mpe2/collect_treasure/collect_treasure.py
+++ b/mpe2/collect_treasure/collect_treasure.py
@@ -380,6 +380,7 @@ class Scenario(BaseScenario):
     def reset_world(self, world: ExtendedWorld, np_random: np.random.Generator) -> None:
         # Store the seeded RNG so post_step can use it for reproducible respawns.
         world.np_random = np_random
+        self._reset_cached_rewards()
 
         for agent in world.agents:
             agent.state.p_pos = np_random.uniform(-1.0, 1.0, world.dim_p)
@@ -405,12 +406,15 @@ class Scenario(BaseScenario):
     def post_step(self, world: ExtendedWorld) -> None:
         self._reset_cached_rewards()
         np_random = world.np_random
+        collecting_reward = 0.0
+        deposit_reward = 0.0
 
         # --- Treasure pickup ---
         for lm in world.landmarks:
             if lm.alive:
                 for collector in self.collectors(world):
                     if collector.holding is None and self._is_collision(lm, collector):
+                        collecting_reward += 5.0
                         lm.alive = False
                         collector.holding = lm.type
                         collector.color = 0.85 * lm.color
@@ -433,9 +437,15 @@ class Scenario(BaseScenario):
                     if deposit.d_i == collector.holding and self._is_collision(
                         collector, deposit
                     ):
+                        deposit_reward += 5.0
                         collector.holding = None
                         collector.color = np.array([0.85, 0.85, 0.85])
                         break
+
+        # Pickup and delivery mutate the conditions used to recognize those events.
+        # Preserve their rewards for the reward calls that follow post_step().
+        self._cached_global_collecting = collecting_reward
+        self._cached_global_deposit = deposit_reward
 
     # ------------------------------------------------------------------
     # Reward
@@ -446,7 +456,7 @@ class Scenario(BaseScenario):
         self._cached_global_deposit: float | None = None
 
     def _global_collecting_reward(self, world: ExtendedWorld) -> float:
-        """+5 for each collector currently touching a live treasure (not holding)."""
+        """+5 for each treasure pickup in the current world step."""
         if self._cached_global_collecting is None:
             rew = 0.0
             for lm in self.treasures(world):
@@ -458,7 +468,7 @@ class Scenario(BaseScenario):
         return self._cached_global_collecting
 
     def _global_deposit_reward(self, world: ExtendedWorld) -> float:
-        """+5 for each collector currently touching its matching deposit."""
+        """+5 for each matching treasure delivery in the current world step."""
         if self._cached_global_deposit is None:
             rew = 0.0
             for d in self.deposits(world):

--- a/test/collect_treasure_test.py
+++ b/test/collect_treasure_test.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mpe2 import collect_treasure_v1
+from mpe2.collect_treasure.collect_treasure import Scenario
+
+
+def _set_position(entity, x: float, y: float) -> None:
+    entity.state.p_pos = np.array([x, y], dtype=float)
+    entity.state.p_vel = np.zeros(2, dtype=float)
+
+
+@pytest.fixture
+def scenario_world():
+    scenario = Scenario()
+    world = scenario.make_world(num_collectors=1, num_deposits=1, num_treasures=1)
+    scenario.reset_world(world, np.random.default_rng(123))
+    return scenario, world
+
+
+@pytest.fixture
+def collect_treasure_env():
+    env = collect_treasure_v1.parallel_env(
+        num_collectors=1, num_deposits=1, num_treasures=1, max_cycles=5
+    )
+    env.reset(seed=123)
+    yield env
+    env.close()
+
+
+def test_pickup_reward_is_preserved_after_post_step(scenario_world) -> None:
+    scenario, world = scenario_world
+    collector, deposit = world.agents
+    treasure = world.landmarks[0]
+
+    _set_position(collector, 0.0, 0.0)
+    _set_position(treasure, 0.0, 0.0)
+    _set_position(deposit, 0.9, 0.9)
+    collector.holding = None
+    treasure.alive = True
+    treasure.type = 0
+
+    scenario.post_step(world)
+
+    assert collector.holding == 0
+    assert treasure.alive is False
+    assert scenario._global_collecting_reward(world) == 5.0
+    assert scenario._global_deposit_reward(world) == 0.0
+    assert scenario._global_reward(world) == 5.0
+
+
+def test_delivery_reward_is_preserved_after_post_step(scenario_world) -> None:
+    scenario, world = scenario_world
+    collector, deposit = world.agents
+    treasure = world.landmarks[0]
+
+    _set_position(collector, 0.0, 0.0)
+    _set_position(deposit, 0.0, 0.0)
+    _set_position(treasure, 0.9, 0.9)
+    collector.holding = 0
+    deposit.d_i = 0
+
+    scenario.post_step(world)
+
+    assert collector.holding is None
+    assert scenario._global_collecting_reward(world) == 0.0
+    assert scenario._global_deposit_reward(world) == 5.0
+    assert scenario._global_reward(world) == 5.0
+
+
+def test_event_rewards_are_returned_by_parallel_step(collect_treasure_env) -> None:
+    env = collect_treasure_env
+    raw_env = env.unwrapped
+    collector, deposit = raw_env.world.agents
+    treasure = raw_env.world.landmarks[0]
+
+    _set_position(collector, 0.0, 0.0)
+    _set_position(treasure, 0.0, 0.0)
+    _set_position(deposit, 1.0, 0.0)
+    treasure.type = 0
+    treasure.respawn_prob = 0.0
+
+    _, pickup_rewards, _, _, _ = env.step({agent: 0 for agent in env.agents})
+
+    assert pickup_rewards == pytest.approx({"collector_0": 4.9, "deposit_0": 4.9})
+
+    _set_position(collector, 1.0, 0.0)
+    _, delivery_rewards, _, _, _ = env.step({agent: 0 for agent in env.agents})
+
+    assert delivery_rewards == pytest.approx({"collector_0": 5.0, "deposit_0": 5.0})
+
+    _, next_rewards, _, _, _ = env.step({agent: 0 for agent in env.agents})
+
+    assert next_rewards == pytest.approx({"collector_0": 0.0, "deposit_0": 0.0})


### PR DESCRIPTION
## Summary

- Cache pickup and matching-delivery rewards before post-step state mutations.
- Reset event reward caches between steps and episodes.
- Add scenario-level and parallel API regression coverage for pickup, delivery, and cache rollover.

## Testing

- `pytest -q test/collect_treasure_test.py` — 3 passed
- Full test suite with coverage — 49 passed, 91% coverage
- `pre-commit run --all-files` — passed
- Source distribution and wheel builds — passed

Closes #61