### PR TITLE
Add configurable radius and k-NN partial observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ The observation space of an agent is a vector generally composed of the agent's 
 
 If an agent cannot see or observe the communication of a second agent, then the second agent is not included in the first's observation space, resulting in different agents having different observation space sizes in certain environments.
 
+### Partial Observability
+
+Some environments provide partial-observability variants. Radius-based variants observe only
+entities within a sensing radius, while k-nearest-neighbour variants observe only the nearest
+agents and landmarks. The two filters can also be combined. Visible entities are either packed
+into compact slots, or the original slots are retained and unobserved entities are zeroed.
+
 ### Action Space
 
 Note: [OpenAI's MPE](https://github.com/openai/multiagent-particle-envs) uses continuous action spaces by default.

--- a/docs/environments/collect_treasure.md
+++ b/docs/environments/collect_treasure.md
@@ -73,6 +73,10 @@ collect_treasure_v1.env(
     max_cycles=25,
     continuous_actions=False,
     dynamic_rescaling=False,
+    num_agent_neighbors=None,
+    num_landmark_neighbors=None,
+    radius=None,
+    knn_mode="compact",
 )
 ```
 
@@ -88,6 +92,16 @@ collect_treasure_v1.env(
 
 `dynamic_rescaling`: Whether to rescale the size of agents and landmarks based on the screen
 size
+
+`num_agent_neighbors`: Optional nearest-agent cap. Agent position, velocity, and role/inventory
+encoding are filtered together.
+
+`num_landmark_neighbors`: Optional nearest-live-treasure cap. Dead treasures remain zero slots.
+
+`radius`: Optional shared sensing radius for agents and live treasures, applied before the caps.
+
+`knn_mode`: ``"compact"`` (default) preserves the existing nearest-first representation;
+``"masked"`` retains stable full agent/treasure slots and zeros unobserved entries.
 ## API
 ```{eval-rst}
 .. currentmodule:: mpe2.collect_treasure.collect_treasure

--- a/docs/environments/simple_adversary.md
+++ b/docs/environments/simple_adversary.md
@@ -43,7 +43,7 @@ Adversary action space: `[no_action, move_left, move_right, move_down, move_up]`
 ### Arguments
 
 ``` python
-simple_adversary_v3.env(N=2, max_cycles=25, continuous_actions=False, dynamic_rescaling=False, num_agent_neighbors=None, num_landmark_neighbors=None)
+simple_adversary_v3.env(N=2, max_cycles=25, continuous_actions=False, dynamic_rescaling=False, num_agent_neighbors=None, num_landmark_neighbors=None, radius=None, knn_mode="compact")
 ```
 
 
@@ -59,7 +59,8 @@ simple_adversary_v3.env(N=2, max_cycles=25, continuous_actions=False, dynamic_re
 `num_agent_neighbors`: **Partial observability.** Maximum number of *other agents* each agent
 observes, selected by Euclidean distance (nearest first).  Observation slots beyond the
 available count are zero-padded so the observation shape remains fixed.
-``None`` (default) = full observability.
+``None`` (default) disables the k cap; when `radius` is also ``None``, all agents are
+observable.
 
     .. warning::
         **Solvability under PO is not guaranteed for simple_adversary.**
@@ -74,7 +75,16 @@ available count are zero-padded so the observation shape remains fixed.
 observes, selected by Euclidean distance (nearest first).  Zero-padded to a fixed size.
 Note: the goal landmark relative position is *always* included in good agents' observations
 regardless of this setting (it is private, 2-D information, not a positional slot).
-``None`` (default) = full observability.
+``None`` (default) disables the k cap; when `radius` is also ``None``, all landmarks are
+observable.
+
+`radius`: Optional shared observation radius for agents and landmarks. Entities outside the
+radius are hidden before applying the optional nearest-neighbour caps. ``None`` (default)
+disables radius filtering. The private goal position remains visible to good agents.
+
+`knn_mode`: Representation used after visibility filtering. ``"compact"`` (default) places
+visible entities in nearest-first slots and pads unused slots. ``"masked"`` retains the full
+observation's stable entity slots and size, replacing unobserved entities with zeros.
 ## API
 ```{eval-rst}
 .. currentmodule:: mpe2.simple_adversary.simple_adversary

--- a/docs/environments/simple_push.md
+++ b/docs/environments/simple_push.md
@@ -42,7 +42,7 @@ Adversary action space: `[no_action, move_left, move_right, move_down, move_up]`
 ### Arguments
 
 ``` python
-simple_push_v3.env(max_cycles=25, continuous_actions=False, dynamic_rescaling=False)
+simple_push_v3.env(max_cycles=25, continuous_actions=False, dynamic_rescaling=False, num_agent_neighbors=None, num_landmark_neighbors=None, radius=None, knn_mode="compact")
 ```
 
 
@@ -50,6 +50,17 @@ simple_push_v3.env(max_cycles=25, continuous_actions=False, dynamic_rescaling=Fa
 `max_cycles`:  number of frames (a step for each agent) until game terminates
 
 `dynamic_rescaling`: Whether to rescale the size of agents and landmarks based on the screen size
+
+`num_agent_neighbors`: Optional nearest-agent cap. There is only one other agent, so radius is
+the more meaningful agent-visibility control.
+
+`num_landmark_neighbors`: Optional nearest-landmark cap.
+
+`radius`: Optional shared sensing radius for agents and landmarks, applied before the caps.
+
+`knn_mode`: ``"compact"`` (default) stores visible entities nearest-first; ``"masked"`` keeps
+the full stable entity slots and zeros hidden entities. Landmark colors remain aligned with
+their position slots. The good agent's private goal-relative position is always retained.
 
 ## API
 ```{eval-rst}

--- a/docs/environments/simple_spread.md
+++ b/docs/environments/simple_spread.md
@@ -40,7 +40,7 @@ Agent action space: `[no_action, move_left, move_right, move_down, move_up]`
 ### Arguments
 
 ``` python
-simple_spread_v3.env(N=3, local_ratio=0.5, max_cycles=25, continuous_actions=False, dynamic_rescaling=False, curriculum=False, num_agent_neighbors=None, num_landmark_neighbors=None)
+simple_spread_v3.env(N=3, local_ratio=0.5, max_cycles=25, continuous_actions=False, dynamic_rescaling=False, curriculum=False, num_agent_neighbors=None, num_landmark_neighbors=None, radius=None, knn_mode="compact")
 ```
 
 
@@ -73,13 +73,23 @@ training signal than always running to `max_cycles`, and pairs naturally with cu
 `num_agent_neighbors`: **Partial observability.** Maximum number of *other agents* each agent
 observes, selected by Euclidean distance (nearest first).  Observation slots beyond the
 available count are zero-padded so the observation shape remains fixed.  Communication signals
-are also filtered to the same N nearest agents.  ``None`` (default) = full observability.
+are also filtered to the same N nearest agents. ``None`` (default) disables the k cap; when
+`radius` is also ``None``, all agents are observable.
 simple_spread is generally solvable under PO – agents can learn locally-greedy covering
 policies without needing global information.
 
 `num_landmark_neighbors`: **Partial observability.** Maximum number of *landmarks* each agent
 observes, selected by Euclidean distance (nearest first).  Zero-padded to a fixed size.
-``None`` (default) = full observability.
+``None`` (default) disables the k cap; when `radius` is also ``None``, all landmarks are
+observable.
+
+`radius`: Optional shared observation radius for agents and landmarks. Entities outside the
+radius are hidden before applying the optional nearest-neighbour caps. ``None`` (default)
+disables radius filtering.
+
+`knn_mode`: Representation used after visibility filtering. ``"compact"`` (default) places
+visible entities in nearest-first slots and pads unused slots. ``"masked"`` retains the full
+observation's stable entity slots and size, replacing unobserved entities with zeros.
 ## API
 ```{eval-rst}
 .. currentmodule:: mpe2.simple_spread.simple_spread

--- a/docs/environments/simple_tag.md
+++ b/docs/environments/simple_tag.md
@@ -49,7 +49,7 @@ Agent and adversary action space: `[no_action, move_left, move_right, move_down,
 ### Arguments
 
 ``` python
-simple_tag_v3.env(num_good=1, num_adversaries=3, num_obstacles=2, max_cycles=25, continuous_actions=False, dynamic_rescaling=False, curriculum=False, num_agent_neighbors=None, num_landmark_neighbors=None)
+simple_tag_v3.env(num_good=1, num_adversaries=3, num_obstacles=2, max_cycles=25, continuous_actions=False, dynamic_rescaling=False, curriculum=False, num_agent_neighbors=None, num_landmark_neighbors=None, radius=None, knn_mode="compact")
 ```
 
 
@@ -74,14 +74,23 @@ on the next `env.reset()`.
 
 `num_agent_neighbors`: **Partial observability.** Maximum number of *other agents* each agent
 observes, selected by Euclidean distance (nearest first).  Observation slots beyond the
-available count are zero-padded so the observation shape remains fixed.  ``None`` (default)
-restores full observability (all agents observed) and preserves backwards-compatibility.
+available count are zero-padded so the observation shape remains fixed. ``None`` (default)
+disables the k cap; when `radius` is also ``None``, all agents are observable.
 Under PO, velocity information is restricted to good agents visible within the neighbour
 window; velocity slots for adversaries or padded slots are zero.
 
 `num_landmark_neighbors`: **Partial observability.** Maximum number of *landmarks* (obstacles)
 each agent observes, selected by Euclidean distance (nearest first).  Zero-padded to a fixed
-size when fewer landmarks are available.  ``None`` (default) = full observability.
+size when fewer landmarks are available. ``None`` (default) disables the k cap; when `radius`
+is also ``None``, all landmarks are observable.
+
+`radius`: Optional shared observation radius for agents and landmarks. Entities outside the
+radius are hidden before applying the optional nearest-neighbour caps. ``None`` (default)
+disables radius filtering.
+
+`knn_mode`: Representation used after visibility filtering. ``"compact"`` (default) places
+visible entities in nearest-first slots and pads unused slots. ``"masked"`` retains the full
+observation's stable entity slots and size, replacing unobserved entities with zeros.
 
 Curriculum stages (prey max_speed / accel as fraction of full speed 1.3 / 4.0):
   - Stage 0: 50% speed — prey is slow and easy to catch.

--- a/docs/environments/simple_world_comm.md
+++ b/docs/environments/simple_world_comm.md
@@ -56,7 +56,9 @@ Adversary leader continuous action space: `[no_action, move_left, move_right, mo
 
 ``` python
 simple_world_comm_v3.env(num_good=2, num_adversaries=4, num_obstacles=1,
-                num_food=2, max_cycles=25, num_forests=2, continuous_actions=False, dynamic_rescaling=False)
+                num_food=2, max_cycles=25, num_forests=2, continuous_actions=False,
+                dynamic_rescaling=False, num_agent_neighbors=None,
+                num_landmark_neighbors=None, radius=None, knn_mode="compact")
 ```
 
 
@@ -76,6 +78,17 @@ simple_world_comm_v3.env(num_good=2, num_adversaries=4, num_obstacles=1,
 `continuous_actions`: Whether agent action spaces are discrete(default) or continuous
 
 `dynamic_rescaling`: Whether to rescale the size of agents and landmarks based on the screen size
+
+`num_agent_neighbors`: Optional nearest-agent cap, composed with the environment's existing
+forest occlusion. Forest-hidden agents do not consume the cap.
+
+`num_landmark_neighbors`: Optional nearest-landmark cap across obstacles, food, and forests.
+
+`radius`: Optional shared sensing radius for agents and landmarks, applied before the caps.
+
+`knn_mode`: ``"compact"`` (default) stores visible entities nearest-first and adds landmark
+color/type features; ``"masked"`` preserves stable full slots and zeros entities hidden by
+range, k, or forest occlusion. The leader's communication remains globally available.
 ## API
 ```{eval-rst}
 .. currentmodule:: mpe2.simple_world_comm.simple_world_comm

--- a/docs/mpe2.md
+++ b/docs/mpe2.md
@@ -38,6 +38,13 @@ The observation space of an agent is a vector generally composed of the agent's 
 
 If an agent cannot see or observe the communication of a second agent, then the second agent is not included in the first's observation space, resulting in different agents having different observation space sizes in certain environments.
 
+## Partial Observability
+
+Some environments provide partial-observability variants. Radius-based variants observe only
+entities within a sensing radius, while k-nearest-neighbour variants observe only the nearest
+agents and landmarks. The two filters can also be combined. Visible entities are either packed
+into compact slots, or the original slots are retained and unobserved entities are zeroed.
+
 ## Action Space
 
 Note: [OpenAI's MPE](https://github.com/openai/multiagent-particle-envs) uses continuous action spaces by default.

--- a/mpe2/_mpe_utils/partial_observability.py
+++ b/mpe2/_mpe_utils/partial_observability.py
@@ -1,9 +1,8 @@
 """Partial observability (PO) utilities for MPE environments.
 
-These helpers implement *N-nearest-neighbour* filtering: instead of an agent
-observing *all* other agents and landmarks, it observes only the **N closest**
-ones.  When fewer entities exist than requested, the remaining observation
-slots are filled with **zeros** so that the observation shape stays fixed.
+These helpers implement nearest-neighbour and radius filtering. Compact
+observations contain nearest-first entity slots, while masked observations
+retain the full-observation slot layout and zero unobserved entities.
 
 Currently used by simple_spread, simple_tag, and simple_adversary. Can be
 extended to other environments as needed.
@@ -11,7 +10,8 @@ extended to other environments as needed.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Sequence, TypeVar
+from numbers import Real
+from typing import TYPE_CHECKING, Callable, Literal, Sequence, TypeVar
 
 import numpy as np
 
@@ -19,34 +19,94 @@ if TYPE_CHECKING:
     from mpe2._mpe_utils.core import Agent, Entity
 
 _EntityT = TypeVar("_EntityT", bound="Entity")
+KNNMode = Literal["compact", "masked"]
+
+
+def validate_partial_observability(
+    num_agent_neighbors: int | None = None,
+    num_landmark_neighbors: int | None = None,
+    radius: float | None = None,
+    knn_mode: KNNMode = "compact",
+) -> None:
+    """Validate the common partial-observability constructor arguments."""
+    assert num_agent_neighbors is None or (
+        isinstance(num_agent_neighbors, int)
+        and not isinstance(num_agent_neighbors, bool)
+        and num_agent_neighbors > 0
+    ), "num_agent_neighbors must be a positive integer or None."
+    assert num_landmark_neighbors is None or (
+        isinstance(num_landmark_neighbors, int)
+        and not isinstance(num_landmark_neighbors, bool)
+        and num_landmark_neighbors > 0
+    ), "num_landmark_neighbors must be a positive integer or None."
+    assert radius is None or (
+        isinstance(radius, Real)
+        and not isinstance(radius, bool)
+        and np.isfinite(radius)
+        and radius > 0
+    ), "radius must be a positive finite number or None."
+    assert knn_mode in (
+        "compact",
+        "masked",
+    ), "knn_mode must be 'compact' or 'masked'."
 
 
 def nearest_entities(
-    agent: Agent, entities: Sequence[_EntityT], n: int | None
+    agent: Agent,
+    entities: Sequence[_EntityT],
+    n: int | None,
+    radius: float | None = None,
 ) -> list[_EntityT]:
-    """Return up to *n* entities nearest to *agent*, sorted closest-first."""
-    if n is None:
+    """Return entities visible by radius and optional nearest-neighbour cap."""
+    if n is None and radius is None:
         return list(entities)
     if not entities:
         return []
     dists = np.array(
         [np.linalg.norm(e.state.p_pos - agent.state.p_pos) for e in entities]
     )
-    order = np.argsort(dists)[:n]
+    order = np.argsort(dists)
+    if radius is not None:
+        order = order[dists[order] <= radius]
+    if n is not None:
+        order = order[:n]
     return [entities[i] for i in order]
 
 
+def observed_entity_slots(
+    agent: Agent,
+    entities: Sequence[_EntityT],
+    n: int | None,
+    radius: float | None = None,
+    knn_mode: KNNMode = "compact",
+) -> list[_EntityT | None]:
+    """Build fixed-size compact or identity-preserving masked entity slots."""
+    selected = nearest_entities(agent, entities, n, radius)
+    if knn_mode == "masked":
+        selected_ids = {id(entity) for entity in selected}
+        return [entity if id(entity) in selected_ids else None for entity in entities]
+    if knn_mode != "compact":
+        raise ValueError("knn_mode must be 'compact' or 'masked'.")
+
+    slot_count = n if n is not None else len(entities)
+    return selected + [None] * (slot_count - len(selected))
+
+
 def padded_relative_positions(
-    agent: Agent, entities: Sequence[Entity], n: int | None, dim_p: int = 2
+    agent: Agent,
+    entities: Sequence[Entity],
+    n: int | None,
+    dim_p: int = 2,
+    *,
+    radius: float | None = None,
+    knn_mode: KNNMode = "compact",
 ) -> list[np.ndarray]:
-    """Relative positions of the *n* nearest entities, zero-padded to *n* slots."""
-    if n is None:
-        return [e.state.p_pos - agent.state.p_pos for e in entities]
-    selected = nearest_entities(agent, entities, n)
-    positions = [e.state.p_pos - agent.state.p_pos for e in selected]
-    while len(positions) < n:
-        positions.append(np.zeros(dim_p))
-    return positions
+    """Relative positions in compact or identity-preserving masked slots."""
+    slots = observed_entity_slots(agent, entities, n, radius, knn_mode)
+    return [
+        np.zeros(dim_p) if entity is None else entity.state.p_pos - agent.state.p_pos
+        for entity in slots
+    ]
 
 
 def padded_velocities(
@@ -55,35 +115,45 @@ def padded_velocities(
     n: int | None,
     predicate: Callable[[_EntityT], bool] | None = None,
     dim_p: int = 2,
+    *,
+    radius: float | None = None,
+    knn_mode: KNNMode = "compact",
 ) -> list[np.ndarray]:
-    """Velocities of the *n* nearest entities, zero-padded to *n* slots."""
-    if n is None:
+    """Velocities in compact or identity-preserving masked slots."""
+    if n is None and radius is None:
         # Full-observability path: respect predicate-based filtering
         if predicate is None:
             return [e.state.p_vel.copy() for e in entities]
         # Original behaviour: only include matching entities (shorter list)
         return [e.state.p_vel.copy() for e in entities if predicate(e)]
-    # PO path: fixed n slots aligned with position output
-    selected = nearest_entities(agent, entities, n)
+    slots = observed_entity_slots(agent, entities, n, radius, knn_mode)
+    if knn_mode == "masked":
+        return [
+            entity.state.p_vel.copy() if slot is not None else np.zeros(dim_p)
+            for entity, slot in zip(entities, slots)
+            if predicate is None or predicate(entity)
+        ]
+
     velocities = []
-    for e in selected:
-        if predicate is None or predicate(e):
-            velocities.append(e.state.p_vel.copy())
+    for entity in slots:
+        if entity is not None and (predicate is None or predicate(entity)):
+            velocities.append(entity.state.p_vel.copy())
         else:
             velocities.append(np.zeros(dim_p))
-    while len(velocities) < n:
-        velocities.append(np.zeros(dim_p))
     return velocities
 
 
 def padded_comms(
-    agent: Agent, entities: Sequence[Agent], n: int | None, dim_c: int
+    agent: Agent,
+    entities: Sequence[Agent],
+    n: int | None,
+    dim_c: int,
+    *,
+    radius: float | None = None,
+    knn_mode: KNNMode = "compact",
 ) -> list[np.ndarray]:
-    """Communication signals of the *n* nearest agents, zero-padded to *n* slots."""
-    if n is None:
-        return [e.state.c.copy() for e in entities]
-    selected = nearest_entities(agent, entities, n)
-    comms = [e.state.c.copy() for e in selected]
-    while len(comms) < n:
-        comms.append(np.zeros(dim_c))
-    return comms
+    """Communication signals in compact or identity-preserving masked slots."""
+    slots = observed_entity_slots(agent, entities, n, radius, knn_mode)
+    return [
+        np.zeros(dim_c) if entity is None else entity.state.c.copy() for entity in slots
+    ]

--- a/mpe2/collect_treasure/collect_treasure.py
+++ b/mpe2/collect_treasure/collect_treasure.py
@@ -65,6 +65,10 @@ collect_treasure_v1.env(
     max_cycles=25,
     continuous_actions=False,
     dynamic_rescaling=False,
+    num_agent_neighbors=None,
+    num_landmark_neighbors=None,
+    radius=None,
+    knn_mode="compact",
 )
 ```
 
@@ -81,6 +85,16 @@ collect_treasure_v1.env(
 `dynamic_rescaling`: Whether to rescale the size of agents and landmarks based on the screen
 size
 
+`num_agent_neighbors`: Optional nearest-agent cap. Agent position, velocity, and role/inventory
+encoding are filtered together.
+
+`num_landmark_neighbors`: Optional nearest-live-treasure cap. Dead treasures remain zero slots.
+
+`radius`: Optional shared sensing radius for agents and live treasures, applied before the caps.
+
+`knn_mode`: ``"compact"`` (default) preserves the existing nearest-first representation;
+``"masked"`` retains stable full agent/treasure slots and zeros unobserved entries.
+
 """
 
 from __future__ import annotations
@@ -92,6 +106,11 @@ from gymnasium.utils import EzPickle
 from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 from mpe2._mpe_utils.core import Agent, Landmark, World
+from mpe2._mpe_utils.partial_observability import (
+    KNNMode,
+    observed_entity_slots,
+    validate_partial_observability,
+)
 from mpe2._mpe_utils.scenario import BaseScenario
 from mpe2._mpe_utils.simple_env import SimpleEnv, make_env
 
@@ -126,7 +145,17 @@ class raw_env(SimpleEnv, EzPickle):
         render_mode: str | None = None,
         dynamic_rescaling: bool = False,
         benchmark_data: bool = False,
+        num_agent_neighbors: int | None = None,
+        num_landmark_neighbors: int | None = None,
+        radius: float | None = None,
+        knn_mode: KNNMode = "compact",
     ) -> None:
+        validate_partial_observability(
+            num_agent_neighbors,
+            num_landmark_neighbors,
+            radius,
+            knn_mode,
+        )
         EzPickle.__init__(
             self,
             num_collectors=num_collectors,
@@ -137,8 +166,17 @@ class raw_env(SimpleEnv, EzPickle):
             render_mode=render_mode,
             dynamic_rescaling=dynamic_rescaling,
             benchmark_data=benchmark_data,
+            num_agent_neighbors=num_agent_neighbors,
+            num_landmark_neighbors=num_landmark_neighbors,
+            radius=radius,
+            knn_mode=knn_mode,
         )
-        scenario = Scenario()
+        scenario = Scenario(
+            num_agent_neighbors=num_agent_neighbors,
+            num_landmark_neighbors=num_landmark_neighbors,
+            radius=radius,
+            knn_mode=knn_mode,
+        )
         world = scenario.make_world(num_collectors, num_deposits, num_treasures)
         SimpleEnv.__init__(
             self,
@@ -279,6 +317,18 @@ class ExtendedWorld(World):
 
 
 class Scenario(BaseScenario):
+    def __init__(
+        self,
+        num_agent_neighbors: int | None = None,
+        num_landmark_neighbors: int | None = None,
+        radius: float | None = None,
+        knn_mode: KNNMode = "compact",
+    ) -> None:
+        self.num_agent_neighbors = num_agent_neighbors
+        self.num_landmark_neighbors = num_landmark_neighbors
+        self.radius = radius
+        self.knn_mode: KNNMode = knn_mode
+
     def make_world(
         self, num_collectors: int = 6, num_deposits: int = 2, num_treasures: int = 6
     ) -> ExtendedWorld:
@@ -563,28 +613,48 @@ class Scenario(BaseScenario):
         if agent.collector:
             obs.append((np.arange(n_types) == agent.holding).astype(float))
 
-        # All other agents, sorted by distance (closest first).
-        others = sorted(
-            (a for a in world.agents if a is not agent),
-            key=lambda a: np.sqrt(np.sum(np.square(a.state.p_pos - agent.state.p_pos))),
+        others = [a for a in world.agents if a is not agent]
+        agent_cap = (
+            self.num_agent_neighbors
+            if self.num_agent_neighbors is not None
+            else len(others)
         )
-        for other in others:
-            obs.append(other.state.p_pos - agent.state.p_pos)
-            obs.append(other.state.p_vel.copy())
-            obs.append(self._get_agent_encoding(other, world))
-
-        # All treasures, alive ones first (sorted by distance), then dead ones.
-        def _treasure_sort_key(lm):
-            if lm.alive:
-                return np.sqrt(np.sum(np.square(lm.state.p_pos - agent.state.p_pos)))
-            return 1e6  # dead treasures sorted to the end
-
-        for lm in sorted(self.treasures(world), key=_treasure_sort_key):
-            if lm.alive:
-                obs.append(lm.state.p_pos - agent.state.p_pos)
-                obs.append((np.arange(n_types) == lm.type).astype(float))
+        agent_slots = observed_entity_slots(
+            agent,
+            others,
+            agent_cap if self.knn_mode == "compact" else self.num_agent_neighbors,
+            self.radius,
+            self.knn_mode,
+        )
+        for other in agent_slots:
+            if other is not None:
+                obs.append(other.state.p_pos - agent.state.p_pos)
+                obs.append(other.state.p_vel.copy())
+                obs.append(self._get_agent_encoding(other, world))
             else:
-                # Zero-pad dead treasures so the observation size stays fixed.
+                obs.append(np.zeros(world.dim_p))
+                obs.append(np.zeros(world.dim_p))
+                obs.append(np.zeros(2 * n_types))
+
+        treasures = self.treasures(world)
+        alive_treasures = [treasure for treasure in treasures if treasure.alive]
+        treasure_cap = (
+            self.num_landmark_neighbors
+            if self.num_landmark_neighbors is not None
+            else len(treasures)
+        )
+        treasure_slots = observed_entity_slots(
+            agent,
+            alive_treasures if self.knn_mode == "compact" else treasures,
+            treasure_cap if self.knn_mode == "compact" else self.num_landmark_neighbors,
+            self.radius,
+            self.knn_mode,
+        )
+        for treasure in treasure_slots:
+            if treasure is not None and treasure.alive:
+                obs.append(treasure.state.p_pos - agent.state.p_pos)
+                obs.append((np.arange(n_types) == treasure.type).astype(float))
+            else:
                 obs.append(np.zeros(world.dim_p))
                 obs.append(np.zeros(n_types))
 

--- a/mpe2/simple_adversary/simple_adversary.py
+++ b/mpe2/simple_adversary/simple_adversary.py
@@ -34,7 +34,7 @@ Adversary action space: `[no_action, move_left, move_right, move_down, move_up]`
 ### Arguments
 
 ``` python
-simple_adversary_v3.env(N=2, max_cycles=25, continuous_actions=False, dynamic_rescaling=False, num_agent_neighbors=None, num_landmark_neighbors=None)
+simple_adversary_v3.env(N=2, max_cycles=25, continuous_actions=False, dynamic_rescaling=False, num_agent_neighbors=None, num_landmark_neighbors=None, radius=None, knn_mode="compact")
 ```
 
 
@@ -50,7 +50,8 @@ simple_adversary_v3.env(N=2, max_cycles=25, continuous_actions=False, dynamic_re
 `num_agent_neighbors`: **Partial observability.** Maximum number of *other agents* each agent
 observes, selected by Euclidean distance (nearest first).  Observation slots beyond the
 available count are zero-padded so the observation shape remains fixed.
-``None`` (default) = full observability.
+``None`` (default) disables the k cap; when `radius` is also ``None``, all agents are
+observable.
 
     .. warning::
         **Solvability under PO is not guaranteed for simple_adversary.**
@@ -65,7 +66,16 @@ available count are zero-padded so the observation shape remains fixed.
 observes, selected by Euclidean distance (nearest first).  Zero-padded to a fixed size.
 Note: the goal landmark relative position is *always* included in good agents' observations
 regardless of this setting (it is private, 2-D information, not a positional slot).
-``None`` (default) = full observability.
+``None`` (default) disables the k cap; when `radius` is also ``None``, all landmarks are
+observable.
+
+`radius`: Optional shared observation radius for agents and landmarks. Entities outside the
+radius are hidden before applying the optional nearest-neighbour caps. ``None`` (default)
+disables radius filtering. The private goal position remains visible to good agents.
+
+`knn_mode`: Representation used after visibility filtering. ``"compact"`` (default) places
+visible entities in nearest-first slots and pads unused slots. ``"masked"`` retains the full
+observation's stable entity slots and size, replacing unobserved entities with zeros.
 
 """
 
@@ -76,7 +86,11 @@ from gymnasium.utils import EzPickle
 from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 from mpe2._mpe_utils.core import Agent, Landmark, World, _require_initialized
-from mpe2._mpe_utils.partial_observability import padded_relative_positions
+from mpe2._mpe_utils.partial_observability import (
+    KNNMode,
+    padded_relative_positions,
+    validate_partial_observability,
+)
 from mpe2._mpe_utils.scenario import BaseScenario
 from mpe2._mpe_utils.simple_env import SimpleEnv, make_env
 
@@ -92,13 +106,15 @@ class raw_env(SimpleEnv, EzPickle):
         benchmark_data: bool = False,
         num_agent_neighbors: int | None = None,
         num_landmark_neighbors: int | None = None,
+        radius: float | None = None,
+        knn_mode: KNNMode = "compact",
     ) -> None:
-        assert num_agent_neighbors is None or (
-            isinstance(num_agent_neighbors, int) and num_agent_neighbors > 0
-        ), "num_agent_neighbors must be a positive integer or None."
-        assert num_landmark_neighbors is None or (
-            isinstance(num_landmark_neighbors, int) and num_landmark_neighbors > 0
-        ), "num_landmark_neighbors must be a positive integer or None."
+        validate_partial_observability(
+            num_agent_neighbors,
+            num_landmark_neighbors,
+            radius,
+            knn_mode,
+        )
         EzPickle.__init__(
             self,
             N=N,
@@ -108,10 +124,14 @@ class raw_env(SimpleEnv, EzPickle):
             benchmark_data=benchmark_data,
             num_agent_neighbors=num_agent_neighbors,
             num_landmark_neighbors=num_landmark_neighbors,
+            radius=radius,
+            knn_mode=knn_mode,
         )
         scenario = Scenario(
             num_agent_neighbors=num_agent_neighbors,
             num_landmark_neighbors=num_landmark_neighbors,
+            radius=radius,
+            knn_mode=knn_mode,
         )
         world = scenario.make_world(N)
         SimpleEnv.__init__(
@@ -158,9 +178,13 @@ class Scenario(BaseScenario):
         self,
         num_agent_neighbors: int | None = None,
         num_landmark_neighbors: int | None = None,
+        radius: float | None = None,
+        knn_mode: KNNMode = "compact",
     ) -> None:
         self.num_agent_neighbors = num_agent_neighbors
         self.num_landmark_neighbors = num_landmark_neighbors
+        self.radius = radius
+        self.knn_mode: KNNMode = knn_mode
 
     def make_world(self, N: int = 2) -> ExtendedWorld:
         world = ExtendedWorld()
@@ -318,13 +342,13 @@ class Scenario(BaseScenario):
 
             The adversary does not know which landmark is the goal.
 
-        Full observability (``num_*_neighbors=None``, default):
+        Full observability (``num_*_neighbors=None`` and ``radius=None``, default):
 
         Partial observability:
-            Landmark and other-agent slots are filtered to the N nearest and
-            zero-padded to maintain a *fixed* observation shape.  The goal
-            relative position (good agents only) is *always* included and is
-            not subject to neighbour filtering.
+            Visibility is filtered by radius and/or the N nearest entities.
+            Compact slots are nearest-first; masked slots retain the full
+            entity layout. Unobserved slots are zeroed in either mode. The
+            goal relative position (good agents only) is *always* included.
 
         .. warning::
             simple_adversary may **not be solvable** under strict PO
@@ -335,21 +359,23 @@ class Scenario(BaseScenario):
         """
         others = [other for other in world.agents if other is not agent]
 
-        # lsndmark
-        if self.num_landmark_neighbors is None:
-            entity_pos = [e.state.p_pos - agent.state.p_pos for e in world.landmarks]
-        else:
-            entity_pos = padded_relative_positions(
-                agent, world.landmarks, self.num_landmark_neighbors
-            )
+        # Landmarks
+        entity_pos = padded_relative_positions(
+            agent,
+            world.landmarks,
+            self.num_landmark_neighbors,
+            radius=self.radius,
+            knn_mode=self.knn_mode,
+        )
 
         # Other agents
-        if self.num_agent_neighbors is None:
-            other_pos = [o.state.p_pos - agent.state.p_pos for o in others]
-        else:
-            other_pos = padded_relative_positions(
-                agent, others, self.num_agent_neighbors
-            )
+        other_pos = padded_relative_positions(
+            agent,
+            others,
+            self.num_agent_neighbors,
+            radius=self.radius,
+            knn_mode=self.knn_mode,
+        )
 
         if not agent.adversary:
             # Goal position is always observable by good agents (private info).

--- a/mpe2/simple_push/simple_push.py
+++ b/mpe2/simple_push/simple_push.py
@@ -33,7 +33,7 @@ Adversary action space: `[no_action, move_left, move_right, move_down, move_up]`
 ### Arguments
 
 ``` python
-simple_push_v3.env(max_cycles=25, continuous_actions=False, dynamic_rescaling=False)
+simple_push_v3.env(max_cycles=25, continuous_actions=False, dynamic_rescaling=False, num_agent_neighbors=None, num_landmark_neighbors=None, radius=None, knn_mode="compact")
 ```
 
 
@@ -41,6 +41,17 @@ simple_push_v3.env(max_cycles=25, continuous_actions=False, dynamic_rescaling=Fa
 `max_cycles`:  number of frames (a step for each agent) until game terminates
 
 `dynamic_rescaling`: Whether to rescale the size of agents and landmarks based on the screen size
+
+`num_agent_neighbors`: Optional nearest-agent cap. There is only one other agent, so radius is
+the more meaningful agent-visibility control.
+
+`num_landmark_neighbors`: Optional nearest-landmark cap.
+
+`radius`: Optional shared sensing radius for agents and landmarks, applied before the caps.
+
+`knn_mode`: ``"compact"`` (default) stores visible entities nearest-first; ``"masked"`` keeps
+the full stable entity slots and zeros hidden entities. Landmark colors remain aligned with
+their position slots. The good agent's private goal-relative position is always retained.
 
 
 """
@@ -52,6 +63,11 @@ from gymnasium.utils import EzPickle
 from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 from mpe2._mpe_utils.core import Agent, Landmark, World, _require_initialized
+from mpe2._mpe_utils.partial_observability import (
+    KNNMode,
+    observed_entity_slots,
+    validate_partial_observability,
+)
 from mpe2._mpe_utils.scenario import BaseScenario
 from mpe2._mpe_utils.simple_env import SimpleEnv, make_env
 
@@ -64,15 +80,34 @@ class raw_env(SimpleEnv, EzPickle):
         render_mode: str | None = None,
         dynamic_rescaling: bool = False,
         benchmark_data: bool = False,
+        num_agent_neighbors: int | None = None,
+        num_landmark_neighbors: int | None = None,
+        radius: float | None = None,
+        knn_mode: KNNMode = "compact",
     ) -> None:
+        validate_partial_observability(
+            num_agent_neighbors,
+            num_landmark_neighbors,
+            radius,
+            knn_mode,
+        )
         EzPickle.__init__(
             self,
             max_cycles=max_cycles,
             continuous_actions=continuous_actions,
             render_mode=render_mode,
             benchmark_data=benchmark_data,
+            num_agent_neighbors=num_agent_neighbors,
+            num_landmark_neighbors=num_landmark_neighbors,
+            radius=radius,
+            knn_mode=knn_mode,
         )
-        scenario = Scenario()
+        scenario = Scenario(
+            num_agent_neighbors=num_agent_neighbors,
+            num_landmark_neighbors=num_landmark_neighbors,
+            radius=radius,
+            knn_mode=knn_mode,
+        )
         world = scenario.make_world()
         SimpleEnv.__init__(
             self,
@@ -120,6 +155,18 @@ class ExtendedWorld(World):
 
 
 class Scenario(BaseScenario):
+    def __init__(
+        self,
+        num_agent_neighbors: int | None = None,
+        num_landmark_neighbors: int | None = None,
+        radius: float | None = None,
+        knn_mode: KNNMode = "compact",
+    ) -> None:
+        self.num_agent_neighbors = num_agent_neighbors
+        self.num_landmark_neighbors = num_landmark_neighbors
+        self.radius = radius
+        self.knn_mode: KNNMode = knn_mode
+
     def make_world(self) -> ExtendedWorld:
         world = ExtendedWorld()
         # set any world properties first
@@ -198,22 +245,42 @@ class Scenario(BaseScenario):
         return pos_rew - neg_rew
 
     def observation(self, agent: ExtendedAgent, world: ExtendedWorld) -> np.ndarray:
-        # get positions of all entities in this agent's reference frame
-        entity_pos = []
-        for entity in world.landmarks:  # world.entities:
-            entity_pos.append(entity.state.p_pos - agent.state.p_pos)
-        # entity colors
-        entity_color = []
-        for entity in world.landmarks:  # world.entities:
-            entity_color.append(entity.color)
-        # communication of all other agents
-        comm = []
-        other_pos = []
-        for other in world.agents:
-            if other is agent:
-                continue
-            comm.append(other.state.c)
-            other_pos.append(other.state.p_pos - agent.state.p_pos)
+        landmark_slots = observed_entity_slots(
+            agent,
+            world.landmarks,
+            self.num_landmark_neighbors,
+            self.radius,
+            self.knn_mode,
+        )
+        entity_pos = [
+            (
+                np.zeros(world.dim_p)
+                if entity is None
+                else entity.state.p_pos - agent.state.p_pos
+            )
+            for entity in landmark_slots
+        ]
+        entity_color = [
+            np.zeros(world.dim_color) if entity is None else entity.color
+            for entity in landmark_slots
+        ]
+
+        others = [other for other in world.agents if other is not agent]
+        agent_slots = observed_entity_slots(
+            agent,
+            others,
+            self.num_agent_neighbors,
+            self.radius,
+            self.knn_mode,
+        )
+        other_pos = [
+            (
+                np.zeros(world.dim_p)
+                if other is None
+                else other.state.p_pos - agent.state.p_pos
+            )
+            for other in agent_slots
+        ]
         if not agent.adversary:
             return np.concatenate(
                 [agent.state.p_vel]

--- a/mpe2/simple_spread/simple_spread.py
+++ b/mpe2/simple_spread/simple_spread.py
@@ -31,7 +31,7 @@ Agent action space: `[no_action, move_left, move_right, move_down, move_up]`
 ### Arguments
 
 ``` python
-simple_spread_v3.env(N=3, local_ratio=0.5, max_cycles=25, continuous_actions=False, dynamic_rescaling=False, curriculum=False, num_agent_neighbors=None, num_landmark_neighbors=None)
+simple_spread_v3.env(N=3, local_ratio=0.5, max_cycles=25, continuous_actions=False, dynamic_rescaling=False, curriculum=False, num_agent_neighbors=None, num_landmark_neighbors=None, radius=None, knn_mode="compact")
 ```
 
 
@@ -64,13 +64,23 @@ training signal than always running to `max_cycles`, and pairs naturally with cu
 `num_agent_neighbors`: **Partial observability.** Maximum number of *other agents* each agent
 observes, selected by Euclidean distance (nearest first).  Observation slots beyond the
 available count are zero-padded so the observation shape remains fixed.  Communication signals
-are also filtered to the same N nearest agents.  ``None`` (default) = full observability.
+are also filtered to the same N nearest agents. ``None`` (default) disables the k cap; when
+`radius` is also ``None``, all agents are observable.
 simple_spread is generally solvable under PO – agents can learn locally-greedy covering
 policies without needing global information.
 
 `num_landmark_neighbors`: **Partial observability.** Maximum number of *landmarks* each agent
 observes, selected by Euclidean distance (nearest first).  Zero-padded to a fixed size.
-``None`` (default) = full observability.
+``None`` (default) disables the k cap; when `radius` is also ``None``, all landmarks are
+observable.
+
+`radius`: Optional shared observation radius for agents and landmarks. Entities outside the
+radius are hidden before applying the optional nearest-neighbour caps. ``None`` (default)
+disables radius filtering.
+
+`knn_mode`: Representation used after visibility filtering. ``"compact"`` (default) places
+visible entities in nearest-first slots and pads unused slots. ``"masked"`` retains the full
+observation's stable entity slots and size, replacing unobserved entities with zeros.
 
 """
 
@@ -82,8 +92,10 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 from mpe2._mpe_utils.core import Agent, Landmark, World
 from mpe2._mpe_utils.partial_observability import (
+    KNNMode,
     padded_comms,
     padded_relative_positions,
+    validate_partial_observability,
 )
 from mpe2._mpe_utils.scenario import BaseScenario
 from mpe2._mpe_utils.simple_env import SimpleEnv, make_env
@@ -103,16 +115,18 @@ class raw_env(SimpleEnv, EzPickle):
         terminate_on_success: bool = False,
         num_agent_neighbors: int | None = None,
         num_landmark_neighbors: int | None = None,
+        radius: float | None = None,
+        knn_mode: KNNMode = "compact",
     ) -> None:
         assert (
             0.0 <= local_ratio <= 1.0
         ), "local_ratio is a proportion. Must be between 0 and 1."
-        assert num_agent_neighbors is None or (
-            isinstance(num_agent_neighbors, int) and num_agent_neighbors > 0
-        ), "num_agent_neighbors must be a positive integer or None."
-        assert num_landmark_neighbors is None or (
-            isinstance(num_landmark_neighbors, int) and num_landmark_neighbors > 0
-        ), "num_landmark_neighbors must be a positive integer or None."
+        validate_partial_observability(
+            num_agent_neighbors,
+            num_landmark_neighbors,
+            radius,
+            knn_mode,
+        )
         EzPickle.__init__(
             self,
             N=N,
@@ -125,12 +139,16 @@ class raw_env(SimpleEnv, EzPickle):
             terminate_on_success=terminate_on_success,
             num_agent_neighbors=num_agent_neighbors,
             num_landmark_neighbors=num_landmark_neighbors,
+            radius=radius,
+            knn_mode=knn_mode,
         )
         scenario = Scenario(
             curriculum=curriculum,
             terminate_on_success=terminate_on_success,
             num_agent_neighbors=num_agent_neighbors,
             num_landmark_neighbors=num_landmark_neighbors,
+            radius=radius,
+            knn_mode=knn_mode,
         )
         world = scenario.make_world(N)
         SimpleEnv.__init__(
@@ -189,12 +207,16 @@ class Scenario(BaseScenario):
         terminate_on_success: bool = False,
         num_agent_neighbors: int | None = None,
         num_landmark_neighbors: int | None = None,
+        radius: float | None = None,
+        knn_mode: KNNMode = "compact",
     ) -> None:
         self.curriculum = curriculum
         self.curriculum_stage = 0
         self.terminate_on_success = terminate_on_success
         self.num_agent_neighbors = num_agent_neighbors
         self.num_landmark_neighbors = num_landmark_neighbors
+        self.radius = radius
+        self.knn_mode: KNNMode = knn_mode
 
     def advance_curriculum(self) -> None:
         """Move to the next curriculum stage. No-op at the final stage."""
@@ -317,33 +339,42 @@ class Scenario(BaseScenario):
     def observation(self, agent: Agent, world: ExtendedWorld) -> np.ndarray:
         """Return the observation vector for *agent*.
 
-        Full observability (``num_*_neighbors=None``, default):
+        Full observability (``num_*_neighbors=None`` and ``radius=None``, default):
 
         Partial observability:
-            Only the N nearest landmarks / other agents are included.
-            Slots are zero-padded to maintain a *fixed* observation shape.
+            Visibility is filtered by radius and/or the N nearest entities.
+            Compact slots are nearest-first; masked slots retain the full
+            entity layout. Unobserved slots are zeroed in either mode.
             Communication slots are aligned with agent position slots (same
-            N nearest agents).
+            visible agents).
         """
         others = [other for other in world.agents if other is not agent]
 
-        # lsndmarks
-        if self.num_landmark_neighbors is None:
-            entity_pos = [e.state.p_pos - agent.state.p_pos for e in world.landmarks]
-        else:
-            entity_pos = padded_relative_positions(
-                agent, world.landmarks, self.num_landmark_neighbors
-            )
+        # Landmarks
+        entity_pos = padded_relative_positions(
+            agent,
+            world.landmarks,
+            self.num_landmark_neighbors,
+            radius=self.radius,
+            knn_mode=self.knn_mode,
+        )
 
         # Other agents + comm
-        if self.num_agent_neighbors is None:
-            other_pos = [o.state.p_pos - agent.state.p_pos for o in others]
-            comm = [o.state.c for o in others]
-        else:
-            other_pos = padded_relative_positions(
-                agent, others, self.num_agent_neighbors
-            )
-            comm = padded_comms(agent, others, self.num_agent_neighbors, world.dim_c)
+        other_pos = padded_relative_positions(
+            agent,
+            others,
+            self.num_agent_neighbors,
+            radius=self.radius,
+            knn_mode=self.knn_mode,
+        )
+        comm = padded_comms(
+            agent,
+            others,
+            self.num_agent_neighbors,
+            world.dim_c,
+            radius=self.radius,
+            knn_mode=self.knn_mode,
+        )
 
         return np.concatenate(
             [agent.state.p_vel] + [agent.state.p_pos] + entity_pos + other_pos + comm

--- a/mpe2/simple_tag/simple_tag.py
+++ b/mpe2/simple_tag/simple_tag.py
@@ -40,7 +40,7 @@ Agent and adversary action space: `[no_action, move_left, move_right, move_down,
 ### Arguments
 
 ``` python
-simple_tag_v3.env(num_good=1, num_adversaries=3, num_obstacles=2, max_cycles=25, continuous_actions=False, dynamic_rescaling=False, curriculum=False, num_agent_neighbors=None, num_landmark_neighbors=None)
+simple_tag_v3.env(num_good=1, num_adversaries=3, num_obstacles=2, max_cycles=25, continuous_actions=False, dynamic_rescaling=False, curriculum=False, num_agent_neighbors=None, num_landmark_neighbors=None, radius=None, knn_mode="compact")
 ```
 
 
@@ -65,14 +65,23 @@ on the next `env.reset()`.
 
 `num_agent_neighbors`: **Partial observability.** Maximum number of *other agents* each agent
 observes, selected by Euclidean distance (nearest first).  Observation slots beyond the
-available count are zero-padded so the observation shape remains fixed.  ``None`` (default)
-restores full observability (all agents observed) and preserves backwards-compatibility.
+available count are zero-padded so the observation shape remains fixed. ``None`` (default)
+disables the k cap; when `radius` is also ``None``, all agents are observable.
 Under PO, velocity information is restricted to good agents visible within the neighbour
 window; velocity slots for adversaries or padded slots are zero.
 
 `num_landmark_neighbors`: **Partial observability.** Maximum number of *landmarks* (obstacles)
 each agent observes, selected by Euclidean distance (nearest first).  Zero-padded to a fixed
-size when fewer landmarks are available.  ``None`` (default) = full observability.
+size when fewer landmarks are available. ``None`` (default) disables the k cap; when `radius`
+is also ``None``, all landmarks are observable.
+
+`radius`: Optional shared observation radius for agents and landmarks. Entities outside the
+radius are hidden before applying the optional nearest-neighbour caps. ``None`` (default)
+disables radius filtering.
+
+`knn_mode`: Representation used after visibility filtering. ``"compact"`` (default) places
+visible entities in nearest-first slots and pads unused slots. ``"masked"`` retains the full
+observation's stable entity slots and size, replacing unobserved entities with zeros.
 
 Curriculum stages (prey max_speed / accel as fraction of full speed 1.3 / 4.0):
   - Stage 0: 50% speed — prey is slow and easy to catch.
@@ -95,8 +104,10 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 from mpe2._mpe_utils.core import Agent, Landmark, World
 from mpe2._mpe_utils.partial_observability import (
+    KNNMode,
     padded_relative_positions,
     padded_velocities,
+    validate_partial_observability,
 )
 from mpe2._mpe_utils.scenario import BaseScenario
 from mpe2._mpe_utils.simple_env import SimpleEnv, make_env
@@ -117,13 +128,15 @@ class raw_env(SimpleEnv, EzPickle):
         terminate_on_success: bool = False,
         num_agent_neighbors: int | None = None,
         num_landmark_neighbors: int | None = None,
+        radius: float | None = None,
+        knn_mode: KNNMode = "compact",
     ) -> None:
-        assert num_agent_neighbors is None or (
-            isinstance(num_agent_neighbors, int) and num_agent_neighbors > 0
-        ), "num_agent_neighbors must be a positive integer or None."
-        assert num_landmark_neighbors is None or (
-            isinstance(num_landmark_neighbors, int) and num_landmark_neighbors > 0
-        ), "num_landmark_neighbors must be a positive integer or None."
+        validate_partial_observability(
+            num_agent_neighbors,
+            num_landmark_neighbors,
+            radius,
+            knn_mode,
+        )
         EzPickle.__init__(
             self,
             num_good=num_good,
@@ -137,12 +150,16 @@ class raw_env(SimpleEnv, EzPickle):
             terminate_on_success=terminate_on_success,
             num_agent_neighbors=num_agent_neighbors,
             num_landmark_neighbors=num_landmark_neighbors,
+            radius=radius,
+            knn_mode=knn_mode,
         )
         scenario = Scenario(
             curriculum=curriculum,
             terminate_on_success=terminate_on_success,
             num_agent_neighbors=num_agent_neighbors,
             num_landmark_neighbors=num_landmark_neighbors,
+            radius=radius,
+            knn_mode=knn_mode,
         )
         world = scenario.make_world(num_good, num_adversaries, num_obstacles)
         SimpleEnv.__init__(
@@ -214,12 +231,16 @@ class Scenario(BaseScenario):
         terminate_on_success: bool = False,
         num_agent_neighbors: int | None = None,
         num_landmark_neighbors: int | None = None,
+        radius: float | None = None,
+        knn_mode: KNNMode = "compact",
     ) -> None:
         self.curriculum = curriculum
         self.curriculum_stage = 0
         self.terminate_on_success = terminate_on_success
         self.num_agent_neighbors = num_agent_neighbors
         self.num_landmark_neighbors = num_landmark_neighbors
+        self.radius = radius
+        self.knn_mode: KNNMode = knn_mode
 
     def advance_curriculum(self) -> None:
         """Move to the next curriculum stage. No-op at the final stage."""
@@ -407,39 +428,44 @@ class Scenario(BaseScenario):
         * ``good_agent_vel`` – velocities of visible good agents (zeros for
                                adversary slots or padded slots)
 
-        Full observability (``num_*_neighbors=None``, default):
+        Full observability (``num_*_neighbors=None`` and ``radius=None``, default):
             All non-boundary landmarks are included; all other agents' positions are included;
             only good agents contribute velocities (matching legacy size).
 
         Partial observability:
-            Only the N nearest landmarks / agents are included.  Slots are
-            zero-padded to maintain a *fixed* observation shape.  Velocity
-            slots for adversary agents within the neighbour window are zeros.
+            Visibility is filtered by radius and/or the N nearest entities.
+            Compact slots are nearest-first; masked slots retain the full
+            entity layout. Unobserved slots are zeroed in either mode.
+            Velocity slots for adversaries are zeros in compact mode.
         """
         # Landmarks ---
         non_boundary_landmarks = [e for e in world.landmarks if not e.boundary]
         entity_pos = padded_relative_positions(
-            agent, non_boundary_landmarks, self.num_landmark_neighbors
+            agent,
+            non_boundary_landmarks,
+            self.num_landmark_neighbors,
+            radius=self.radius,
+            knn_mode=self.knn_mode,
         )
 
         # Other agents ---
         others = [other for other in world.agents if other is not agent]
 
-        if self.num_agent_neighbors is None:
-            # Full observability
-            other_pos = [o.state.p_pos - agent.state.p_pos for o in others]
-            other_vel = [o.state.p_vel for o in others if not o.adversary]
-        else:
-            # Partial observability
-            other_pos = padded_relative_positions(
-                agent, others, self.num_agent_neighbors
-            )
-            other_vel = padded_velocities(
-                agent,
-                others,
-                self.num_agent_neighbors,
-                predicate=lambda e: not e.adversary,
-            )
+        other_pos = padded_relative_positions(
+            agent,
+            others,
+            self.num_agent_neighbors,
+            radius=self.radius,
+            knn_mode=self.knn_mode,
+        )
+        other_vel = padded_velocities(
+            agent,
+            others,
+            self.num_agent_neighbors,
+            predicate=lambda e: not e.adversary,
+            radius=self.radius,
+            knn_mode=self.knn_mode,
+        )
 
         return np.concatenate(
             [agent.state.p_vel]

--- a/mpe2/simple_world_comm/simple_world_comm.py
+++ b/mpe2/simple_world_comm/simple_world_comm.py
@@ -47,7 +47,9 @@ Adversary leader continuous action space: `[no_action, move_left, move_right, mo
 
 ``` python
 simple_world_comm_v3.env(num_good=2, num_adversaries=4, num_obstacles=1,
-                num_food=2, max_cycles=25, num_forests=2, continuous_actions=False, dynamic_rescaling=False)
+                num_food=2, max_cycles=25, num_forests=2, continuous_actions=False,
+                dynamic_rescaling=False, num_agent_neighbors=None,
+                num_landmark_neighbors=None, radius=None, knn_mode="compact")
 ```
 
 
@@ -68,6 +70,17 @@ simple_world_comm_v3.env(num_good=2, num_adversaries=4, num_obstacles=1,
 
 `dynamic_rescaling`: Whether to rescale the size of agents and landmarks based on the screen size
 
+`num_agent_neighbors`: Optional nearest-agent cap, composed with the environment's existing
+forest occlusion. Forest-hidden agents do not consume the cap.
+
+`num_landmark_neighbors`: Optional nearest-landmark cap across obstacles, food, and forests.
+
+`radius`: Optional shared sensing radius for agents and landmarks, applied before the caps.
+
+`knn_mode`: ``"compact"`` (default) stores visible entities nearest-first and adds landmark
+color/type features; ``"masked"`` preserves stable full slots and zeros entities hidden by
+range, k, or forest occlusion. The leader's communication remains globally available.
+
 """
 
 from __future__ import annotations
@@ -77,6 +90,12 @@ from gymnasium.utils import EzPickle
 from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 from mpe2._mpe_utils.core import Agent, Entity, Landmark, World
+from mpe2._mpe_utils.partial_observability import (
+    KNNMode,
+    nearest_entities,
+    observed_entity_slots,
+    validate_partial_observability,
+)
 from mpe2._mpe_utils.scenario import BaseScenario
 from mpe2._mpe_utils.simple_env import SimpleEnv, make_env
 
@@ -94,7 +113,17 @@ class raw_env(SimpleEnv, EzPickle):
         render_mode: str | None = None,
         dynamic_rescaling: bool = False,
         benchmark_data: bool = False,
+        num_agent_neighbors: int | None = None,
+        num_landmark_neighbors: int | None = None,
+        radius: float | None = None,
+        knn_mode: KNNMode = "compact",
     ) -> None:
+        validate_partial_observability(
+            num_agent_neighbors,
+            num_landmark_neighbors,
+            radius,
+            knn_mode,
+        )
         EzPickle.__init__(
             self,
             num_good=num_good,
@@ -106,8 +135,17 @@ class raw_env(SimpleEnv, EzPickle):
             continuous_actions=continuous_actions,
             render_mode=render_mode,
             benchmark_data=benchmark_data,
+            num_agent_neighbors=num_agent_neighbors,
+            num_landmark_neighbors=num_landmark_neighbors,
+            radius=radius,
+            knn_mode=knn_mode,
         )
-        scenario = Scenario()
+        scenario = Scenario(
+            num_agent_neighbors=num_agent_neighbors,
+            num_landmark_neighbors=num_landmark_neighbors,
+            radius=radius,
+            knn_mode=knn_mode,
+        )
         world = scenario.make_world(
             num_good, num_adversaries, num_obstacles, num_food, num_forests
         )
@@ -151,6 +189,18 @@ class ExtendedWorld(World):
 
 
 class Scenario(BaseScenario):
+    def __init__(
+        self,
+        num_agent_neighbors: int | None = None,
+        num_landmark_neighbors: int | None = None,
+        radius: float | None = None,
+        knn_mode: KNNMode = "compact",
+    ) -> None:
+        self.num_agent_neighbors = num_agent_neighbors
+        self.num_landmark_neighbors = num_landmark_neighbors
+        self.radius = radius
+        self.knn_mode: KNNMode = knn_mode
+
     def make_world(
         self,
         num_good_agents: int = 2,
@@ -404,70 +454,103 @@ class Scenario(BaseScenario):
         )
 
     def observation(self, agent: ExtendedAgent, world: ExtendedWorld) -> np.ndarray:
-        # get positions of all entities in this agent's reference frame
-        entity_pos = []
-        for entity in world.landmarks:
-            if not entity.boundary:
-                entity_pos.append(entity.state.p_pos - agent.state.p_pos)
+        landmarks = [entity for entity in world.landmarks if not entity.boundary]
+        landmark_slots = observed_entity_slots(
+            agent,
+            landmarks,
+            self.num_landmark_neighbors,
+            self.radius,
+            self.knn_mode,
+        )
+        entity_pos = [
+            (
+                np.zeros(world.dim_p)
+                if entity is None
+                else entity.state.p_pos - agent.state.p_pos
+            )
+            for entity in landmark_slots
+        ]
+        entity_color = (
+            [
+                np.zeros(world.dim_color) if entity is None else entity.color
+                for entity in landmark_slots
+            ]
+            if self.knn_mode == "compact"
+            and (self.num_landmark_neighbors is not None or self.radius is not None)
+            else []
+        )
 
         in_forest = [np.array([-1]) for _ in range(len(world.forests))]
-        inf = [False for _ in range(len(world.forests))]
-
-        for i in range(len(world.forests)):
-            if self.is_collision(agent, world.forests[i]):
+        agent_forests = [self.is_collision(agent, forest) for forest in world.forests]
+        for i, is_inside in enumerate(agent_forests):
+            if is_inside:
                 in_forest[i] = np.array([1])
-                inf[i] = True
 
-        food_pos = []
-        for entity in world.food:
-            if not entity.boundary:
-                food_pos.append(entity.state.p_pos - agent.state.p_pos)
-        # communication of all other agents
-        comm = []
-        other_pos = []
-        other_vel = []
-        for other in world.agents:
-            if other is agent:
-                continue
-            comm.append(other.state.c)
+        others = [other for other in world.agents if other is not agent]
 
-            oth_f = [
-                self.is_collision(other, world.forests[i])
-                for i in range(len(world.forests))
+        def visible_through_forest(other: ExtendedAgent) -> bool:
+            if agent.leader:
+                return True
+            other_forests = [
+                self.is_collision(other, forest) for forest in world.forests
+            ]
+            return any(
+                observer_inside and other_inside
+                for observer_inside, other_inside in zip(agent_forests, other_forests)
+            ) or (not any(agent_forests) and not any(other_forests))
+
+        forest_visible = [other for other in others if visible_through_forest(other)]
+        compact_agent_po = self.knn_mode == "compact" and (
+            self.num_agent_neighbors is not None or self.radius is not None
+        )
+        if compact_agent_po:
+            agent_cap = (
+                self.num_agent_neighbors
+                if self.num_agent_neighbors is not None
+                else len(others)
+            )
+            agent_slots = observed_entity_slots(
+                agent,
+                forest_visible,
+                agent_cap,
+                self.radius,
+                self.knn_mode,
+            )
+        else:
+            selected = nearest_entities(
+                agent,
+                forest_visible,
+                self.num_agent_neighbors,
+                self.radius,
+            )
+            selected_ids = {id(other) for other in selected}
+            agent_slots = [
+                other if id(other) in selected_ids else None for other in others
             ]
 
-            # without forest vis
-            for i in range(len(world.forests)):
-                if inf[i] and oth_f[i]:
-                    other_pos.append(other.state.p_pos - agent.state.p_pos)
-                    if not other.adversary:
-                        other_vel.append(other.state.p_vel)
-                    break
-            else:
-                if ((not any(inf)) and (not any(oth_f))) or agent.leader:
-                    other_pos.append(other.state.p_pos - agent.state.p_pos)
-                    if not other.adversary:
-                        other_vel.append(other.state.p_vel)
-                else:
-                    other_pos.append([0, 0])
-                    if not other.adversary:
-                        other_vel.append([0, 0])
-
-        # to tell the pred when the prey are in the forest
-        prey_forest = []
-        ga = self.good_agents(world)
-        for a in ga:
-            if any([self.is_collision(a, f) for f in world.forests]):
-                prey_forest.append(np.array([1]))
-            else:
-                prey_forest.append(np.array([-1]))
-        # to tell leader when pred are in forest
-        prey_forest_lead = []
-        for f in world.forests:
-            if any([self.is_collision(a, f) for a in ga]):
-                prey_forest_lead.append(np.array([1]))
-            else:
-                prey_forest_lead.append(np.array([-1]))
+        other_pos = [
+            (
+                np.zeros(world.dim_p)
+                if other is None
+                else other.state.p_pos - agent.state.p_pos
+            )
+            for other in agent_slots
+        ]
+        if compact_agent_po:
+            other_vel = [
+                (
+                    other.state.p_vel
+                    if other is not None and not other.adversary
+                    else np.zeros(world.dim_p)
+                )
+                for other in agent_slots
+            ]
+        else:
+            other_vel = [
+                slot.state.p_vel if slot is not None else np.zeros(world.dim_p)
+                for other, slot in zip(others, agent_slots)
+                if not other.adversary
+            ]
 
         comm = [world.agents[0].state.c]
 
@@ -476,6 +559,7 @@ class Scenario(BaseScenario):
                 [agent.state.p_vel]
                 + [agent.state.p_pos]
                 + entity_pos
+                + entity_color
                 + other_pos
                 + other_vel
                 + in_forest
@@ -486,6 +570,7 @@ class Scenario(BaseScenario):
                 [agent.state.p_vel]
                 + [agent.state.p_pos]
                 + entity_pos
+                + entity_color
                 + other_pos
                 + other_vel
                 + in_forest
@@ -496,6 +581,7 @@ class Scenario(BaseScenario):
                 [agent.state.p_vel]
                 + [agent.state.p_pos]
                 + entity_pos
+                + entity_color
                 + other_pos
                 + in_forest
                 + other_vel

--- a/test/all_parameter_combs_test.py
+++ b/test/all_parameter_combs_test.py
@@ -107,6 +107,75 @@ partial_obs_envs = [
         simple_adversary_v3,
         dict(N=3, num_agent_neighbors=2, max_cycles=50),
     ],
+    # Masked k-NN keeps full-sized, stable entity slots.
+    [
+        simple_spread_v3,
+        dict(
+            N=4,
+            num_agent_neighbors=2,
+            num_landmark_neighbors=2,
+            knn_mode="masked",
+            max_cycles=50,
+        ),
+    ],
+    # Radius-only PO uses full-capacity compact slots.
+    [
+        simple_tag_v3,
+        dict(
+            num_good=2,
+            num_adversaries=3,
+            num_obstacles=2,
+            radius=0.75,
+            max_cycles=50,
+        ),
+    ],
+    # Radius filtering composes with k-NN caps and masked slots.
+    [
+        simple_adversary_v3,
+        dict(
+            N=3,
+            num_agent_neighbors=2,
+            num_landmark_neighbors=2,
+            radius=1.0,
+            knn_mode="masked",
+            max_cycles=50,
+        ),
+    ],
+    # Collect Treasure: typed agents/treasures remain aligned in compact PO.
+    [
+        collect_treasure_v1,
+        dict(
+            num_collectors=4,
+            num_deposits=2,
+            num_treasures=4,
+            num_agent_neighbors=2,
+            num_landmark_neighbors=2,
+            radius=1.0,
+            max_cycles=50,
+        ),
+    ],
+    # Simple Push: positions and landmark colors are filtered together.
+    [
+        simple_push_v3,
+        dict(
+            num_agent_neighbors=1,
+            num_landmark_neighbors=1,
+            radius=1.0,
+            knn_mode="masked",
+            max_cycles=50,
+        ),
+    ],
+    # World Comm composes distance filtering with forest occlusion.
+    [
+        simple_world_comm_v3,
+        dict(
+            num_agent_neighbors=3,
+            num_landmark_neighbors=3,
+            radius=1.0,
+            knn_mode="masked",
+            max_cycles=50,
+        ),
+    ],
 ]
 
 parameterized_envs = [

--- a/test/partial_observability_test.py
+++ b/test/partial_observability_test.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mpe2 import (
+    collect_treasure_v1,
+    simple_adversary_v3,
+    simple_crypto_v3,
+    simple_formation_v1,
+    simple_line_v1,
+    simple_push_v3,
+    simple_reference_v3,
+    simple_speaker_listener_v4,
+    simple_spread_v3,
+    simple_tag_v3,
+    simple_v3,
+    simple_world_comm_v3,
+)
+from mpe2._mpe_utils.core import Agent, Landmark
+from mpe2._mpe_utils.partial_observability import padded_relative_positions
+
+
+def _agent_at(x: float, y: float) -> Agent:
+    agent = Agent()
+    agent.state.p_pos = np.array([x, y], dtype=np.float32)
+    agent.state.p_vel = np.zeros(2, dtype=np.float32)
+    agent.state.c = np.zeros(2, dtype=np.float32)
+    return agent
+
+
+def _landmark_at(x: float, y: float) -> Landmark:
+    landmark = Landmark()
+    landmark.state.p_pos = np.array([x, y], dtype=np.float32)
+    landmark.state.p_vel = np.zeros(2, dtype=np.float32)
+    return landmark
+
+
+def test_compact_knn_keeps_nearest_first() -> None:
+    observer = _agent_at(0.0, 0.0)
+    entities = [
+        _landmark_at(3.0, 0.0),
+        _landmark_at(0.5, 0.0),
+        _landmark_at(1.0, 0.0),
+    ]
+
+    positions = padded_relative_positions(observer, entities, 2)
+
+    np.testing.assert_array_equal(positions, [[0.5, 0.0], [1.0, 0.0]])
+
+
+def test_masked_knn_preserves_full_entity_slots() -> None:
+    observer = _agent_at(0.0, 0.0)
+    entities = [
+        _landmark_at(3.0, 0.0),
+        _landmark_at(0.5, 0.0),
+        _landmark_at(1.0, 0.0),
+    ]
+
+    positions = padded_relative_positions(observer, entities, 2, knn_mode="masked")
+
+    np.testing.assert_array_equal(positions, [[0.0, 0.0], [0.5, 0.0], [1.0, 0.0]])
+
+
+def test_radius_filters_before_optional_knn_cap() -> None:
+    observer = _agent_at(0.0, 0.0)
+    entities = [
+        _landmark_at(0.75, 0.0),
+        _landmark_at(0.25, 0.0),
+        _landmark_at(2.0, 0.0),
+    ]
+
+    uncapped = padded_relative_positions(observer, entities, None, radius=1.0)
+    capped = padded_relative_positions(observer, entities, 1, radius=1.0)
+    masked = padded_relative_positions(
+        observer, entities, None, radius=1.0, knn_mode="masked"
+    )
+
+    np.testing.assert_array_equal(uncapped, [[0.25, 0.0], [0.75, 0.0], [0.0, 0.0]])
+    np.testing.assert_array_equal(capped, [[0.25, 0.0]])
+    np.testing.assert_array_equal(masked, [[0.75, 0.0], [0.25, 0.0], [0.0, 0.0]])
+
+
+@pytest.mark.parametrize(
+    ("env_module", "kwargs"),
+    [
+        (
+            simple_spread_v3,
+            {
+                "N": 4,
+                "num_agent_neighbors": 2,
+                "num_landmark_neighbors": 2,
+            },
+        ),
+        (
+            simple_tag_v3,
+            {
+                "num_good": 1,
+                "num_adversaries": 3,
+                "num_obstacles": 2,
+                "num_agent_neighbors": 2,
+                "num_landmark_neighbors": 1,
+            },
+        ),
+        (
+            simple_adversary_v3,
+            {
+                "N": 3,
+                "num_agent_neighbors": 2,
+                "num_landmark_neighbors": 1,
+            },
+        ),
+        (
+            collect_treasure_v1,
+            {
+                "num_collectors": 4,
+                "num_deposits": 2,
+                "num_treasures": 4,
+                "num_agent_neighbors": 2,
+                "num_landmark_neighbors": 2,
+            },
+        ),
+        (
+            simple_push_v3,
+            {"num_agent_neighbors": 1, "num_landmark_neighbors": 1},
+        ),
+        (
+            simple_world_comm_v3,
+            {"num_agent_neighbors": 3, "num_landmark_neighbors": 3},
+        ),
+    ],
+)
+def test_masked_mode_keeps_full_observation_shape(env_module, kwargs) -> None:
+    full_kwargs = dict(kwargs)
+    for key in ("num_agent_neighbors", "num_landmark_neighbors"):
+        if key in full_kwargs:
+            full_kwargs[key] = None
+    full_env = env_module.env(**full_kwargs)
+    masked_env = env_module.env(**kwargs, knn_mode="masked")
+    full_env.reset(seed=0)
+    masked_env.reset(seed=0)
+
+    for agent in full_env.agents:
+        assert (
+            masked_env.observation_space(agent).shape
+            == full_env.observation_space(agent).shape
+        )
+
+    full_env.close()
+    masked_env.close()
+
+
+@pytest.mark.parametrize(
+    "env_module",
+    [
+        simple_spread_v3,
+        simple_tag_v3,
+        simple_adversary_v3,
+        collect_treasure_v1,
+        simple_push_v3,
+        simple_world_comm_v3,
+    ],
+)
+def test_radius_mode_has_fixed_declared_observation_shape(env_module) -> None:
+    env = env_module.env(radius=0.5)
+    env.reset(seed=0)
+
+    for agent in env.agents:
+        assert env.observe(agent).shape == env.observation_space(agent).shape
+
+    env.close()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"radius": 0.0},
+        {"radius": float("inf")},
+        {"knn_mode": "unknown"},
+    ],
+)
+def test_partial_observability_arguments_are_validated(kwargs) -> None:
+    with pytest.raises(AssertionError):
+        simple_spread_v3.env(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "env_module",
+    [
+        simple_v3,
+        simple_crypto_v3,
+        simple_formation_v1,
+        simple_line_v1,
+        simple_reference_v3,
+        simple_speaker_listener_v4,
+    ],
+)
+def test_landmark_only_or_nonspatial_environments_do_not_expose_po(env_module) -> None:
+    with pytest.raises(TypeError):
+        env_module.env(radius=0.5)


### PR DESCRIPTION
## Summary

Adds configurable partial-observability variants to:

- Collect Treasure
- Simple Adversary
- Simple Push
- Simple Spread
- Simple Tag
- Simple World Comm

## Changes

- Add radius-based entity visibility.
- Add optional nearest-neighbor caps for agents and landmarks.
- Support two observation representations:
  - `compact`: visible entities occupy nearest-first slots.
  - `masked`: original entity slots are preserved and hidden entities are zeroed.
- Allow radius and k-NN filtering to be combined.
- Preserve existing fully observable behavior by default.
- Keep entity position, velocity, communication, role, and type features aligned.
- Compose distance filtering with existing forest occlusion in Simple World Comm.
- Add shared validation and partial-observability utilities.
- Update environment documentation, README, and general MPE2 documentation.
- Add behavioral and PettingZoo API regression coverage.
