### PR TITLE
fix: align environment docs with implementation

### DIFF
--- a/docs/environments/simple_crypto.md
+++ b/docs/environments/simple_crypto.md
@@ -19,7 +19,7 @@ This environment is part of the <a href='https://mpe2.farama.org/mpe2/'>MPE2 env
 | Parallel API       | Yes                                           |
 | Manual Control     | No                                            |
 | Agents             | `agents= [eve_0, bob_0, alice_0]`             |
-| Agent  Count       | 2                                             |
+| Agent Count        | 3                                             |
 | Action Shape       | (4)                                           |
 | Action Values      | Discrete(4)/Box(0.0, 1.0, (4))                |
 | Observation Shape  | (4),(8)                                       |

--- a/docs/environments/simple_reference.md
+++ b/docs/environments/simple_reference.md
@@ -20,11 +20,11 @@ This environment is part of the <a href='https://mpe2.farama.org/mpe2/'>MPE2 env
 | Manual Control     | No                                               |
 | Agents             | `agents= [agent_0, agent_1]`                     |
 | Agent Count        | 2                                                |
-| Action Shape       | (5)                                              |
-| Action Values      | Discrete(5)/Box(0.0, 1.0, (5))                   |
-| Observation Shape  | (8),(10)                                         |
+| Action Shape       | (50)                                             |
+| Action Values      | Discrete(50)/Box(0.0, 1.0, (15))                 |
+| Observation Shape  | (21),(21)                                        |
 | Observation Values | (-inf,inf)                                       |
-| State Shape        | (28,)                                            |
+| State Shape        | (42,)                                            |
 | State Values       | (-inf,inf)                                       |
 
 
@@ -32,7 +32,7 @@ This environment has 2 agents and 3 landmarks of different colors. Each agent wa
 
 Locally, the agents are rewarded by their distance to their target landmark. Globally, all agents are rewarded by the average distance of all the agents to their respective landmarks. The relative weight of these rewards is controlled by the `local_ratio` parameter.
 
-Agent observation space: `[self_vel, all_landmark_rel_positions, landmark_ids, goal_id, communication]`
+Agent observation space: `[self_vel, all_landmark_rel_positions, goal_landmark_color, communication]`
 
 Agent discrete action space: `[say_0, say_1, say_2, say_3, say_4, say_5, say_6, say_7, say_8, say_9] X [no_action, move_left, move_right, move_down, move_up]`
 

--- a/docs/environments/simple_speaker_listener.md
+++ b/docs/environments/simple_speaker_listener.md
@@ -30,11 +30,11 @@ This environment is part of the <a href='https://mpe2.farama.org/mpe2/'>MPE2 env
 
 This environment is similar to simple_reference, except that one agent is the 'speaker' (gray) and can speak but cannot move, while the other agent is the listener (cannot speak, but must navigate to correct landmark).
 
-Speaker observation space: `[goal_id]`
+Speaker observation space: `[goal_landmark_color]`
 
 Listener observation space: `[self_vel, all_landmark_rel_positions, communication]`
 
-Speaker action space: `[say_0, say_1, say_2, say_3, say_4, say_5, say_6, say_7, say_8, say_9]`
+Speaker action space: `[say_0, say_1, say_2]`
 
 Listener action space: `[no_action, move_left, move_right, move_down, move_up]`
 

--- a/docs/environments/simple_tag.md
+++ b/docs/environments/simple_tag.md
@@ -21,7 +21,7 @@ This environment is part of the <a href='https://mpe2.farama.org/mpe2/'>MPE2 env
 | Agents             | `agents= [adversary_0, adversary_1, adversary_2, agent_0]` |
 | Agent Count        | 4                                                          |
 | Action Shape       | (5)                                                        |
-| Action Values      | Discrete(5)/Box(0.0, 1.0, (50))                            |
+| Action Values      | Discrete(5)/Box(0.0, 1.0, (5))                             |
 | Observation Shape  | (14),(16)                                                  |
 | Observation Values | (-inf,inf)                                                 |
 | State Shape        | (62,)                                                      |

--- a/docs/environments/simple_world_comm.md
+++ b/docs/environments/simple_world_comm.md
@@ -18,7 +18,7 @@ This environment is part of the <a href='https://mpe2.farama.org/mpe2/'>MPE2 env
 | Actions            | Discrete/Continuous                                                                 |
 | Parallel API       | Yes                                                                                 |
 | Manual Control     | No                                                                                  |
-| Agents             | `agents=[leadadversary_0, adversary_0, adversary_1, adversary_3, agent_0, agent_1]` |
+| Agents             | `agents=[leadadversary_0, adversary_0, adversary_1, adversary_2, agent_0, agent_1]` |
 | Agent Count        | 6                                                                                   |
 | Action Shape       | (5),(20)                                                                            |
 | Action Values      | Discrete(5),(20)/Box(0.0, 1.0, (5)), Box(0.0, 1.0, (9))                             |
@@ -29,7 +29,7 @@ This environment is part of the <a href='https://mpe2.farama.org/mpe2/'>MPE2 env
 
 
 This environment is similar to simple_tag, except there is food (small blue balls) that the good agents are rewarded for being near, there are 'forests' that hide agents inside from being seen, and there is a 'leader adversary' that can see the agents at all times and can communicate with the
-other adversaries to help coordinate the chase. By default, there are 2 good agents, 3 adversaries, 1 obstacles, 2 foods, and 2 forests.
+other adversaries to help coordinate the chase. By default, there are 2 good agents, 4 adversaries, 1 obstacle, 2 foods, and 2 forests.
 
 In particular, the good agents reward, is -5 for every collision with an adversary, -2 x bound by the `bound` function described in simple_tag, +2 for every collision with a food, and -0.05 x minimum distance to any food. The adversarial agents are rewarded +5 for collisions and -0.1 x minimum
 distance to a good agent. s
@@ -48,7 +48,7 @@ Normal adversary action space: `[no_action, move_left, move_right, move_down, mo
 
 Adversary leader discrete action space: `[say_0, say_1, say_2, say_3] X [no_action, move_left, move_right, move_down, move_up]`
 
-Where X is the Cartesian product (giving a total action space of 50).
+Where X is the Cartesian product (giving a total action space of 20).
 
 Adversary leader continuous action space: `[no_action, move_left, move_right, move_down, move_up, say_0, say_1, say_2, say_3]`
 

--- a/mpe2/simple_crypto/simple_crypto.py
+++ b/mpe2/simple_crypto/simple_crypto.py
@@ -10,7 +10,7 @@ This environment is part of the <a href='https://mpe2.farama.org/mpe2/'>MPE2 env
 | Parallel API       | Yes                                           |
 | Manual Control     | No                                            |
 | Agents             | `agents= [eve_0, bob_0, alice_0]`             |
-| Agent  Count       | 2                                             |
+| Agent Count        | 3                                             |
 | Action Shape       | (4)                                           |
 | Action Values      | Discrete(4)/Box(0.0, 1.0, (4))                |
 | Observation Shape  | (4),(8)                                       |

--- a/mpe2/simple_reference/simple_reference.py
+++ b/mpe2/simple_reference/simple_reference.py
@@ -11,11 +11,11 @@ This environment is part of the <a href='https://mpe2.farama.org/mpe2/'>MPE2 env
 | Manual Control     | No                                               |
 | Agents             | `agents= [agent_0, agent_1]`                     |
 | Agent Count        | 2                                                |
-| Action Shape       | (5)                                              |
-| Action Values      | Discrete(5)/Box(0.0, 1.0, (5))                   |
-| Observation Shape  | (8),(10)                                         |
+| Action Shape       | (50)                                             |
+| Action Values      | Discrete(50)/Box(0.0, 1.0, (15))                 |
+| Observation Shape  | (21),(21)                                        |
 | Observation Values | (-inf,inf)                                       |
-| State Shape        | (28,)                                            |
+| State Shape        | (42,)                                            |
 | State Values       | (-inf,inf)                                       |
 
 
@@ -23,7 +23,7 @@ This environment has 2 agents and 3 landmarks of different colors. Each agent wa
 
 Locally, the agents are rewarded by their distance to their target landmark. Globally, all agents are rewarded by the average distance of all the agents to their respective landmarks. The relative weight of these rewards is controlled by the `local_ratio` parameter.
 
-Agent observation space: `[self_vel, all_landmark_rel_positions, landmark_ids, goal_id, communication]`
+Agent observation space: `[self_vel, all_landmark_rel_positions, goal_landmark_color, communication]`
 
 Agent discrete action space: `[say_0, say_1, say_2, say_3, say_4, say_5, say_6, say_7, say_8, say_9] X [no_action, move_left, move_right, move_down, move_up]`
 

--- a/mpe2/simple_speaker_listener/simple_speaker_listener.py
+++ b/mpe2/simple_speaker_listener/simple_speaker_listener.py
@@ -21,11 +21,11 @@ This environment is part of the <a href='https://mpe2.farama.org/mpe2/'>MPE2 env
 
 This environment is similar to simple_reference, except that one agent is the 'speaker' (gray) and can speak but cannot move, while the other agent is the listener (cannot speak, but must navigate to correct landmark).
 
-Speaker observation space: `[goal_id]`
+Speaker observation space: `[goal_landmark_color]`
 
 Listener observation space: `[self_vel, all_landmark_rel_positions, communication]`
 
-Speaker action space: `[say_0, say_1, say_2, say_3, say_4, say_5, say_6, say_7, say_8, say_9]`
+Speaker action space: `[say_0, say_1, say_2]`
 
 Listener action space: `[no_action, move_left, move_right, move_down, move_up]`
 

--- a/mpe2/simple_tag/simple_tag.py
+++ b/mpe2/simple_tag/simple_tag.py
@@ -12,7 +12,7 @@ This environment is part of the <a href='https://mpe2.farama.org/mpe2/'>MPE2 env
 | Agents             | `agents= [adversary_0, adversary_1, adversary_2, agent_0]` |
 | Agent Count        | 4                                                          |
 | Action Shape       | (5)                                                        |
-| Action Values      | Discrete(5)/Box(0.0, 1.0, (50))                            |
+| Action Values      | Discrete(5)/Box(0.0, 1.0, (5))                             |
 | Observation Shape  | (14),(16)                                                  |
 | Observation Values | (-inf,inf)                                                 |
 | State Shape        | (62,)                                                      |

--- a/mpe2/simple_world_comm/simple_world_comm.py
+++ b/mpe2/simple_world_comm/simple_world_comm.py
@@ -9,7 +9,7 @@ This environment is part of the <a href='https://mpe2.farama.org/mpe2/'>MPE2 env
 | Actions            | Discrete/Continuous                                                                 |
 | Parallel API       | Yes                                                                                 |
 | Manual Control     | No                                                                                  |
-| Agents             | `agents=[leadadversary_0, adversary_0, adversary_1, adversary_3, agent_0, agent_1]` |
+| Agents             | `agents=[leadadversary_0, adversary_0, adversary_1, adversary_2, agent_0, agent_1]` |
 | Agent Count        | 6                                                                                   |
 | Action Shape       | (5),(20)                                                                            |
 | Action Values      | Discrete(5),(20)/Box(0.0, 1.0, (5)), Box(0.0, 1.0, (9))                             |
@@ -20,7 +20,7 @@ This environment is part of the <a href='https://mpe2.farama.org/mpe2/'>MPE2 env
 
 
 This environment is similar to simple_tag, except there is food (small blue balls) that the good agents are rewarded for being near, there are 'forests' that hide agents inside from being seen, and there is a 'leader adversary' that can see the agents at all times and can communicate with the
-other adversaries to help coordinate the chase. By default, there are 2 good agents, 3 adversaries, 1 obstacles, 2 foods, and 2 forests.
+other adversaries to help coordinate the chase. By default, there are 2 good agents, 4 adversaries, 1 obstacle, 2 foods, and 2 forests.
 
 In particular, the good agents reward, is -5 for every collision with an adversary, -2 x bound by the `bound` function described in simple_tag, +2 for every collision with a food, and -0.05 x minimum distance to any food. The adversarial agents are rewarded +5 for collisions and -0.1 x minimum
 distance to a good agent. s
@@ -39,7 +39,7 @@ Normal adversary action space: `[no_action, move_left, move_right, move_down, mo
 
 Adversary leader discrete action space: `[say_0, say_1, say_2, say_3] X [no_action, move_left, move_right, move_down, move_up]`
 
-Where X is the Cartesian product (giving a total action space of 50).
+Where X is the Cartesian product (giving a total action space of 20).
 
 Adversary leader continuous action space: `[no_action, move_left, move_right, move_down, move_up, say_0, say_1, say_2, say_3]`
 


### PR DESCRIPTION
Fixes #72 

This PR fixes several inconsistencies between the environment documentation and the current implementation.

The changes are documentation-only and do not modify environment behavior.